### PR TITLE
Reduce CI run times

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -118,7 +118,7 @@ jobs:
         uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
         with:
           inlineScript: |
-            secrets_get=(productionHostname resourceGroupName cdnProfileName cdnName accountName)
+            secrets_get=(resourceGroupName cdnProfileName cdnName accountName)
             for secret_get in ${secrets_get[@]}
             do
               value=$(az keyvault secret show --name $secret_get --vault-name ${{ secrets.AZURE_KEY_VAULT }} --query value --output tsv)
@@ -202,7 +202,8 @@ jobs:
                   --profile-name ${{steps.keyvault.outputs.cdnProfileName}} \
                   --endpoint-name ${{steps.keyvault.outputs.cdnName}} \
                   --domains $DOMAIN_PREVIEW \
-                  --content-paths "${PREVIEW_URL_PATH}/*"
+                  --content-paths "${PREVIEW_URL_PATH}/*" \
+                  --no-wait
 
       - name: Azure upload to specified environment
         uses: azure/cli@965c8d7571d2231a54e321ddd07f7b10317f34d9 # v2.0.0
@@ -223,7 +224,8 @@ jobs:
                   --profile-name ${{steps.keyvault.outputs.cdnProfileName}} \
                   --endpoint-name ${{steps.keyvault.outputs.cdnName}} \
                   --domains $DEPLOYMENT_DOMAIN \
-                  --content-paths "${PRODUCTION_URL_PATH}/*"
+                  --content-paths "${PRODUCTION_URL_PATH}/*" \
+                  --no-wait
 
       - name: Azure logout
         run: |


### PR DESCRIPTION
We're adding the --no-wait flag here because the CDN purge step takes forever to run. Removing the unused secret decreases time spent in the keyvault step.

<img width="1284" alt="Screenshot 2024-06-28 at 4 05 43 PM" src="https://github.com/nginxinc/docs-actions/assets/667598/ebce6357-423f-413b-8176-1c613c5ccb11">

This test shows that build times are back down to around a minute. @nginx-jack how can we best verify that the CDN purge actually happens?

## Caveats

Using `--no-wait` instead of parallelizing or splitting the purge step into a new job simplifies the action but introduces the risk of silent failure.