### PR TITLE
bump hugo theme version

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -245,7 +245,7 @@ jobs:
             const previewUrlPath = process.env.PREVIEW_URL_PATH;
             const prNumber = context.payload.pull_request.number;
 
-            const previewUrl = `https://${previewHostname}${previewUrlPath}${prNumber}/`;
+            const previewUrl = `https://${previewHostname}${previewUrlPath}/${prNumber}/`;
 
             const body = `### <span aria-hidden="true">✅</span> Deploy Preview will be available once build job completes!
 


### PR DESCRIPTION
Bump hugo theme version to pull in search_token endpoint fix

DO NOT MERGE until https://github.com/nginxinc/nginx-hugo-theme/pull/66 has been merged, and had a matching release created.