### PR TITLE
Add check for external contributor

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -49,7 +49,27 @@ env:
   DOMAIN_PROD: "docs.nginx.com"
 
 jobs:
+  checks:
+    name: Checks and variables
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      forked_workflow: ${{ steps.vars.outputs.forked_workflow }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Set Variables
+        id: vars
+        run: |
+          echo "forked_workflow=${{ (github.event.pull_request && github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) || !(startsWith(github.repository, 'nginx/') || startsWith(github.repository, 'nginxinc/')) }}" >> $GITHUB_OUTPUT
+      - name: Output variables
+        run: |
+          echo forked_workflow: ${{ steps.vars.outputs.forked_workflow }}
   build:
+    needs: [checks]
+    if: ${{ needs.checks.outputs.forked_workflow == 'false' }}
     runs-on: ubuntu-latest
     env:
       # Remapping of inputs to envs

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ _note: autodeploy from branch is currently in progress. This docs will be update
 
 ## Usage
 
+_note: This action **will not work** with Pull Requests on forked repositories. GitHub does not allow secrets to be shared with forked Pull Requests. Secrets are required as part of Azure interactions. The "Checks and variables" job stops this action from running on forked repositories._
+
 ### Security considerations
 `AZURE_CREDENTIALS` need to contain service principal credentials with the following roles assigned;
 - **Storage Blob Data Contributor**


### PR DESCRIPTION
### Proposed changes
Community PR preview builds will always fail because forks cannot get access to github secrets. 
NIC have implemented this on their repository with this PR https://github.com/nginxinc/kubernetes-ingress/pull/6123, but ideally this would be managed directly in docs-actions, to avoid code duplication across OSS repos.

**Expected Behavior**

    Creating a PR from a fork will not run the docs-actions, they will be skipped
    Creating a PR directly on the repo will continue to operate as it does currently

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CHANGELOG.md))
