### PR TITLE
Set fetch depth to 0 to pull history to fix hugo lastmod

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -169,6 +169,8 @@ jobs:
 
       - name: Checkout docs content
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.7.1
+        with:
+          fetch-depth: 0 # This is required for hugo Lastmod to function properly
 
       - name: Get latest hugo theme
         if: inputs.doc_type == 'hugo' && inputs.force_hugo_theme_version == ''


### PR DESCRIPTION
### Proposed changes

We use [Hugo Lastmod](https://gohugo.io/methods/page/lastmod/) to generate `last-modified` metadata in our rendered pages, as well as `lastmod` values across site maps.
By default, the github checkout action only fetches at a depth of `1`, which is faster and fine for most cases. Hugo uses this to figure out the last modified date, so all metadata was being set to the current date, and therefore incorrect.
For our largest repo, this add 4 seconds to our checkout time, which we can afford 😅 .

Add `enableGitInfo=true` to hugo's `config.toml`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CHANGELOG.md))
