### PR TITLE
Add buildInfo.json to static dir

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -195,6 +195,20 @@ jobs:
           hugo-version: ${{env.HUGO_VERSION}}
           extended: true
 
+      - name: Add hugo build info
+        if: inputs.doc_type == 'hugo'
+        run: |
+          timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          cat <<EOF > buildInfo.json
+          {
+              "nginxHugoThemeVersion": "$THEME_MODULE@$THEME_VERSION",
+              "buildDate": "$timestamp"
+          }
+          EOF
+          mkdir -p ${{inputs.docs_build_path}}/static/
+          cp buildInfo.json ${{inputs.docs_build_path}}/static/
+
+
       - name: Build Hugo for PR preview
         if: inputs.doc_type == 'hugo' && (github.event.action == 'synchronize' || github.event.action == 'opened' || env.DEPLOYMENT_ENV == 'preview')
         working-directory: ${{inputs.docs_build_path}}


### PR DESCRIPTION
### Proposed changes

This creates a `buildInfo.json` file containing the theme version and the timestamp of the build.
The idea being, that we could have a script call the `buildInfo.json` endpoint for each site build, and aggregate the info, or warn us of themes being out of date.
This can easily be expanded to include more data as we want.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CHANGELOG.md))
