### PR TITLE
Tweak(docs-build-push): Use sync/AzCopy in-lieu of batch-upload

### DIFF
--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -298,14 +298,13 @@ jobs:
         with:
           inlineScript: |
             cd ${{inputs.docs_build_path}} \
-            && az storage blob upload-batch \
+            && az storage blob sync \
                  -s $DOCS_SOURCE_PATH \
-                 -d '$web' \
-                 --destination-path "dev/${{github.repository}}/previews/${PR_NUMBER}" \
+                 -c '$web' \
+                 --destination "dev/${{github.repository}}/previews/${PR_NUMBER}" \
                  --account-name ${{ env.AZ_ACCOUNT }} \
-                 --overwrite \
-                 --content-cache-control "max-age=3600" \
-                 --auth-mode login
+                 --auth-mode login \
+                 -- --compare-hash=MD5
 
                  az afd endpoint purge \
                   --resource-group ${{ env.AZ_RESOURCE_GROUP }} \
@@ -321,14 +320,13 @@ jobs:
         with:
           inlineScript: |
             cd ${{inputs.docs_build_path}} \
-            && az storage blob upload-batch \
+            && az storage blob sync \
                  -s $DOCS_SOURCE_PATH \
-                 -d '$web' \
-                 --destination-path "${STORAGE_PREFIX}/${{github.repository}}/latest/" \
+                 -c '$web' \
+                 --destination "${STORAGE_PREFIX}/${{github.repository}}/latest/" \
                  --account-name ${{ env.AZ_ACCOUNT }} \
-                 --overwrite \
-                 --content-cache-control "max-age=3600" \
                  --auth-mode login
+                 -- --compare-hash=MD5
 
                az afd endpoint purge \
                   --resource-group ${{ env.AZ_RESOURCE_GROUP }} \

--- a/.github/workflows/docs-build-push.yml
+++ b/.github/workflows/docs-build-push.yml
@@ -325,7 +325,7 @@ jobs:
                  -c '$web' \
                  --destination "${STORAGE_PREFIX}/${{github.repository}}/latest/" \
                  --account-name ${{ env.AZ_ACCOUNT }} \
-                 --auth-mode login
+                 --auth-mode login \
                  -- --compare-hash=MD5
 
                az afd endpoint purge \


### PR DESCRIPTION
### Proposed changes

* Operation has changed from a push to a recursive diff sync.
* Resolves long-standing issues in docs.nginx.com if files are deleted/moved
* Greatly improves job times in large content sets like TechDocs, even in full sync contexts (i.e 1st preview deployment).
  * Subsequent deployments in the same ctx will always be faster, as the basis for upload targeting is an entity's MD5 hash.

### Test Runs

* [Full sync - TechDocs preview](https://github.com/nginxinc/aem-hugo/actions/runs/29043110107)
* [Diff sync - TechDocs preview](https://github.com/nginxinc/aem-hugo/actions/runs/29043747440)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/{{REPOSITORY_OWNER}}/{{REPOSITORY_URL}}/blob/main/CHANGELOG.md))
